### PR TITLE
Fixed rpd module related issue (#677)

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -546,8 +546,14 @@ def main():
                     resp = junos_module.dev.rpc(rpc,
                                        normalize=bool(format == 'xml'))
                 else:
-                    resp = junos_module.get_rpc(rpc,
+                    try:
+                        resp = junos_module.get_rpc(rpc,
                                        ignore_warning=ignore_warning, format=format)
+                    except Exception as ex:
+                        if "RpcError" in (str(ex)):
+                            raise junos_module.pyez_exception.RpcError
+                        if "ConnectError" in (str(ex)):
+                            raise junos_module.pyez_exception.ConnectError
                 result['msg'] = 'The RPC executed successfully.'
                 junos_module.logger.debug('RPC "%s" executed successfully.',
                                           junos_module.etree.tostring(


### PR DESCRIPTION
When performing an RPC get with an RPC that is not implemented for a platform, it fails when using a PyEZ connection. With a local connection, the response is “Unable to execute the RPC” and it continues with the next RPC get. PyEZ behavior should be the same as with the local connection.